### PR TITLE
Bump io.papermc.paper:paper-api

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,3 +1,3 @@
 dependencies {
-    compileOnlyApi("io.papermc.paper:paper-api:1.19.4-R0.1-SNAPSHOT")
+    compileOnlyApi("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
     implementation("de.maxhenkel.voicechat:voicechat-api:2.4.11")
     //implementation("dev.arbjerg:lavaplayer:2.2.1")
     implementation("dev.arbjerg:lavaplayer:f67aae9d591bb2343f16065f03ac5d7a1538b1d7-SNAPSHOT")


### PR DESCRIPTION
Bumps io.papermc.paper:paper-api from 1.19.4-R0.1-SNAPSHOT to 1.21.3-R0.1-SNAPSHOT.

---
updated-dependencies:
- dependency-name: io.papermc.paper:paper-api dependency-type: direct:production update-type: version-update:semver-minor ...